### PR TITLE
refactor: swap flake-compat for call-flake

### DIFF
--- a/tmpls/local/local/flake.nix
+++ b/tmpls/local/local/flake.nix
@@ -3,13 +3,13 @@
   inputs.nosys.url = "github:divnix/nosys";
   inputs.nixpkgs.url = "github:nixos/nixpkgs/nixpkgs-unstable";
   inputs.devshell.url = "github:numtide/devshell";
-  inputs.flake-compat.url = "github:edolstra/flake-compat?ref=refs/pull/55/head";
+  inputs.call-flake.url = "github:divnix/call-flake";
   outputs = inputs @ {
     nosys,
-    flake-compat,
+    call-flake,
     ...
   }:
-    nosys ((flake-compat ../.).inputs // inputs) (
+    nosys ((call-flake ../.).inputs // inputs) (
       {
         self,
         nixpkgs,


### PR DESCRIPTION
Works with latest [amendments](https://github.com/divnix/call-flake/commit/bc78245aba4acb1f7d028fefc4e5decfb05c3328) to `divnix/call-flake`.

Thanks @figsoda on figuring out how to circumvent `fetchTree` on "non-locked" `isPath`.