### PR TITLE
feat: specially handle `pkgs` input

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,38 @@ simply override systems as a list:
 ```nix
 nosys (inputs' // {systems = ["x86_64-darwin"];}) # ({self, ...}:
 ```
-## Cross Compilation
 
-For advanced cases like cross-compilation the system's are still available in the usual place when
+# Nixpkgs Convenience
+
+Defining a flake input called `pkgs` that points to a checkout of nixos/nixpkgs will be handled
+specially, for convenience purposes. Instead of simply desystemizing the input, the package set
+will also be brought to the top-level of the flake's output schema for convenience. Additionally,
+nixpkgs `lib` output will be brought into scope for quick reference of library functions. e.g:
+
+```nix
+{
+  inputs.pkgs.url = "github:nixos/nixpkgs/nixpkgs-unstable";
+  outputs = inputs:
+    nosys inputs ({
+      lib, # can reference nixpkgs `lib` directly from output functor
+      pkgs,
+      ...
+    }: {
+      packages.default = pkgs.foo; # instead of pkgs.legacyPackages.foo
+    });
+}
+```
+
+If you need to configure the nixpkgs collection, you can do so by adding the expected `config`
+attribute to the inputs passed to `nosys`:
+```nix
+nosys (inputs // {config.allowUnfree = true;}) ({pkgs, ...}: {
+  # unfree packages are now usable from `pkgs` here
+})
+```
+
+
+## Cross Compilation, et al.
+
+For advanced cases like cross-compilation the systems are still available in the usual place when
 needing to reference a different system than the one currently being defined. 

--- a/README.md
+++ b/README.md
@@ -3,6 +3,30 @@ SPDX-FileCopyrightText: 2022 The Standard Authors
 
 SPDX-License-Identifier: Unlicense
 -->
+# Why?
+
+There is a long-standing conversation about Nix flakes concerning the handling of
+different system architectures. There has been a lot of back and forth and a lot of
+brainstorming, but for the time being, things have mostly stagnated.
+
+For now, this flake is a straightforward demonstration of the "system as an input"
+concept that has been thrown around for a while now. It is not perfect, and might be
+more appropriate to be handled by Nix upstream eventually, but does offer some genuine
+convenience.
+
+In practice, it makes handling the flake output schema easier when you just don't
+care too much about specially handling the system architecture.
+
+It is deliberately simple, and otherwise keeps the output schema of flakes unmodified
+which should hopefully allow it to work seamlessly with more elaborate tools or flake
+libraries if desired. In fact, it is already an upstream of
+[paisano](https://github.com/paisano-nix/core) to provide this same convenience in that
+project.
+
+In addition, there are also a few optional niceties such as special
+[nixpkgs handling](#nixpkgs-convenience), and an escape hatch for outputs that don't
+need to be system specced.
+
 # Init
 
 `nix flake new project -t github:divnix/nosys`
@@ -42,9 +66,9 @@ in {
     buildInputs = with pkgs; [/* ... */];
   };
 
-  # attributes prefixed with 1 (`_`) are kept system independant and the leading `_` is removed
-  _lib.f = x: x;
-  # attributes with 2 (`__`) underscores are passed through unmodified
+  # attributes prefixed with a single underscore (`_`) are kept system independant
+  _lib.f = x: x; # becomes `outputs.lib.f` in the final flake
+  # attributes with two underscores (`__`) underscores are passed through unmodified
   __functor = self: self.lib.f;
 
 }

--- a/flake.nix
+++ b/flake.nix
@@ -6,20 +6,49 @@
   outputs = {self}: {
     __functor = self: self.lib.noSys;
 
-    lib.noSys = inputs @ {systems ? import ./systems.nix, ...}: f: let
+    lib.noSys = inputs @ {
+      systems ? import ./systems.nix,
+      config ? {},
+      ...
+    }: f: let
       systems' =
         if builtins.isPath systems || systems ? outPath
         then import systems
         else systems;
     in
-      self.lib.eachSys systems' (sys: let
+      self.lib.eachSys systems' (system: let
         f' = inputs: let
           # mapAttrs to deSys up to the same depths as in `self`
-          inputs' = builtins.mapAttrs (_: self.lib.deSys sys) (builtins.removeAttrs inputs ["self"]);
-          self' = self.lib.deSys sys (builtins.removeAttrs inputs.self ["inputs"]);
+          inputs' = builtins.mapAttrs (k: v: let
+            input = self.lib.deSys system v;
+          in
+            if
+              k
+              == "pkgs"
+              && v ? legacyPackages
+              && v.inputs == {}
+              && builtins.pathExists "${v}/default.nix"
+            then let
+              pkgs =
+                if inputs ? config && inputs.config != {}
+                then
+                  import v {
+                    inherit system config;
+                  }
+                else input.legacyPackages;
+            in
+              pkgs // input
+            else input) (builtins.removeAttrs inputs ["self"]);
+          self' = self.lib.deSys system (builtins.removeAttrs inputs.self ["inputs"]);
         in
           # must be recombined after `deSys` to avoid infinite recursion
-          f (inputs' // {self = self';});
+          f ((
+              if inputs ? pkgs && inputs.pkgs ? lib
+              then {inherit (inputs.pkgs) lib;}
+              else {}
+            )
+            // inputs'
+            // {self = self';});
       in
         f' inputs);
 


### PR DESCRIPTION
If nixpkgs is declared in a flake as the `pkgs` input, then the package collection will automatically be imported under the given input for quick access, e.g. `pkgs.zlib` instead of `pkgs.legacyPackages.zlib`.

In addition, the `lib` attribute will be brought into the top-level of the functor arguments for quick reference, e.g. `nosys inputs ({lib, pkgs, ...}: {})`